### PR TITLE
Adding GitHub template files & dev requirements file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,9 +9,9 @@ If you would like to contribute anything, fork the repo and open a Pull Request 
 The best way to ensure that git history is not jumbled up too much is to add an `upstream` remote:
 
 ```bash
-$ git clone ...your_fastats_fork_url...
-$ cd fastats
-$ git remote add upstream https://github.com/fastats/fastats
+$ git clone ...your_reasonable_fork_url...
+$ cd reasonable
+$ git remote add upstream https://github.com/fastats/reasonable
 ```
 
 Then you can fetch from `upstream` remote and create new features on your fork easily:
@@ -28,16 +28,13 @@ Issues are turned off forever. We prefer Pull Requests for everything.
 
 There's many reasons for this, [this gist][bad_issues] from Ryan Florence details them nicely.
 
-If you have questions about using the library, please feel free to ask
-questions on the [fastats mailing list](https://groups.google.com/forum/#!forum/fastats)
-
 
 ## Reporting bugs and requesting changes
 
 - To report a bug, open a PR with a unittest that fails.
 - To request an API change/new functionality, open a PR with a failing unittest showing your
   preferred API.
-- To submit a fix, open a PR with passing unittests + doctests.
+- To submit a fix, open a PR with passing unittests.
 
 Simples :)
 
@@ -50,36 +47,36 @@ requirements.
 Some of the tests require extra libraries that are not required for normal
 installation.
 
-One way to develop `fastats` code is to work in a virtual environment and
-install `[dev]` requirements bundle:
+One way to develop `reasonable` code is to work in a virtual environment and
+install the requirements from `requirements-dev.txt`:
 
 ```bash
 $ pwd
-/your/github/checkout/of/fastats
+/your/github/checkout/of/reasonable
 $ python3 -m pip install virtualenv --user
 $ python3 -m virtualenv venv
 $ . venv/bin/activate
-$ pip install -e .[dev]
+$ pip install -r requirements-dev.txt
 ```
 
 Such install will ensure that all requirements are met, and that the changes
-to `fastats` code are immediately visible.
+to `reasonable` code are immediately visible.
 
 #### IDEs
 
 Advanced IDEs, such as PyCharm, will allow you to create the virtualenv
 using GUI and pointing the project interpreter at it.  All you have to do then
 is fire up the terminal in the IDE, ensure you're in venv and run
-`pip install -e .[dev]`.  This should enable things like
+`pip install -r requirements-dev.txt`.  This should enable things like
 `right-click -> run py.test` etc.
 
 
-#### windows
+#### Windows
 
-If you're on windows, the procedure should be analogous - except
+If you're on Windows, the procedure should be analogous - except
 `activate` is a script that can be called directly.
 
-One problem that we've seen on windows is that `statsmodels` won't install
+One problem that we've seen on Windows is that `statsmodels` won't install
 unless `numpy` is installed first.  The solution is to run `pip install numpy`
 before `pip install -e .[dev]`.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,7 +78,7 @@ If you're on Windows, the procedure should be analogous - except
 
 One problem that we've seen on Windows is that `statsmodels` won't install
 unless `numpy` is installed first.  The solution is to run `pip install numpy`
-before `pip install -e .[dev]`.
+before `pip install -r requirements-dev.txt`.
 
 
 ## Code style

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contribution guide
+
+All contributions are welcome! :)
+
+If you would like to contribute anything, fork the repo and open a Pull Request (PR).
+
+## Recommended git workflow
+
+The best way to ensure that git history is not jumbled up too much is to add an `upstream` remote:
+
+```bash
+$ git clone ...your_fastats_fork_url...
+$ cd fastats
+$ git remote add upstream https://github.com/fastats/fastats
+```
+
+Then you can fetch from `upstream` remote and create new features on your fork easily:
+
+```bash
+$ git fetch upstream
+$ git checkout -b my_awesome_branch upstream/master
+```
+
+
+## Issues
+
+Issues are turned off forever. We prefer Pull Requests for everything.
+
+There's many reasons for this, [this gist][bad_issues] from Ryan Florence details them nicely.
+
+If you have questions about using the library, please feel free to ask
+questions on the [fastats mailing list](https://groups.google.com/forum/#!forum/fastats)
+
+
+## Reporting bugs and requesting changes
+
+- To report a bug, open a PR with a unittest that fails.
+- To request an API change/new functionality, open a PR with a failing unittest showing your
+  preferred API.
+- To submit a fix, open a PR with passing unittests + doctests.
+
+Simples :)
+
+
+## Installing requirements for development
+
+To ease dependency management, we rely on `setup.py` script to contain the
+requirements.
+
+Some of the tests require extra libraries that are not required for normal
+installation.
+
+One way to develop `fastats` code is to work in a virtual environment and
+install `[dev]` requirements bundle:
+
+```bash
+$ pwd
+/your/github/checkout/of/fastats
+$ python3 -m pip install virtualenv --user
+$ python3 -m virtualenv venv
+$ . venv/bin/activate
+$ pip install -e .[dev]
+```
+
+Such install will ensure that all requirements are met, and that the changes
+to `fastats` code are immediately visible.
+
+#### IDEs
+
+Advanced IDEs, such as PyCharm, will allow you to create the virtualenv
+using GUI and pointing the project interpreter at it.  All you have to do then
+is fire up the terminal in the IDE, ensure you're in venv and run
+`pip install -e .[dev]`.  This should enable things like
+`right-click -> run py.test` etc.
+
+
+#### windows
+
+If you're on windows, the procedure should be analogous - except
+`activate` is a script that can be called directly.
+
+One problem that we've seen on windows is that `statsmodels` won't install
+unless `numpy` is installed first.  The solution is to run `pip install numpy`
+before `pip install -e .[dev]`.
+
+
+## Code style
+
+We tend to follow [PEP8][pep8] for Python code style, with a few exceptions:
+
+- All `.py` files should begin with a blank line (blame @dwillmer for this).
+- One-letter and upper-case variable names might be acceptable where they make sense, especially in
+  linear algebra functions dealing with matrices.
+
+### Before submitting your code for PR:
+
+- Make sure all your `.py` files always end with a blank line (this is good practice,
+  also for other file formats).
+- Make sure your source files are `UTF-8` encoded.
+- Make sure you have tests (test coverage is automatically enforced on every PR).
+
+#### Tests
+
+- Doctests should be minimal, and serve as API docs for the most common use cases.
+
+  - For doctests, you should place this at the bottom of your module (followed by a blank line, ofc):
+
+    ```python
+    if __name__ == '__main__':
+        import pytest
+        pytest.main([__file__])
+    ```
+      
+    This ensures that you can "run" every doctest in the module ad-hoc.
+  
+  - Note that some doctests require special setup / options that are provided by pytest.
+    Because of this, they won't work on their own.
+    
+    See the `conftest.py` and `pytest.ini` files for more details.
+
+- Unittests should be exhaustive and should reside in the `tests` directory.
+
+
+[bad_issues]: https://gist.github.com/ryanflorence/8a62abea562ca2896dee
+[pep8]: https://pep8.org/

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+
+New Feature
+
+- [ ] Code conforms to style guide
+- [ ] Doctests
+- [ ] Unit-tests
+- [ ] Documentation
+- [ ] New line item in [releases.md](https://github.com/fastats/fastats/blob/master/releases.md)
+- [ ] Info added to `literature` directory
+
+Bug Report
+
+- [ ] Minimal repro in a test function

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,11 @@
 
-New Feature
+New Feature:
 
 - [ ] Code conforms to style guide
-- [ ] Doctests
 - [ ] Unit-tests
 - [ ] Documentation
-- [ ] New line item in [releases.md](https://github.com/fastats/fastats/blob/master/releases.md)
-- [ ] Info added to `literature` directory
+- [ ] New line item in [releases.md](https://github.com/fastats/reasonable/blob/master/releases.md)
 
-Bug Report
+Bug Report:
 
 - [ ] Minimal repro in a test function

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,7 @@ python:
   - 3.6
   - 3.6-dev
 before_install:
-  - pip install numpy
-  - pip install scipy
-  - pip install scikit-learn
-  - pip install numba
-  - pip install hypothesis
-  - pip install pytest 
-  - pip install pytest-cov
-  - pip install codecov
-  - pip install sphinx
-  - pip install sphinx_rtd_theme
+  - pip install -r requirements-dev.txt
 script:
   - pytest
   - sphinx-build docs docs/_build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
 hypothesis
 numpy
 scipy
-pytest>=4
+pytest>=3.5.0
 pytest-cov
 codecov
 sphinx
 sphinx_rtd_theme
+attrs>=17.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 hypothesis
 numpy
 scipy
-pytest>=3.5.0
+pytest>=4
 pytest-cov
 codecov
 sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,8 @@
 hypothesis
-pytest
 numpy
 scipy
+pytest
+pytest-cov
+codecov
+sphinx
+sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+hypothesis
+pytest
+numpy
+scipy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 hypothesis
 numpy
 scipy
+pytest>=4
 pytest-cov
 codecov
-pytest
 sphinx
 sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 hypothesis
 numpy
 scipy
-pytest
 pytest-cov
 codecov
+pytest
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
GitHub templates mostly taken from fastats with some minor adaptations for the lack of required doctests. requirements-dev taken from the travis setup, with some reqs that weren't being used removed.

The attrs requirement is annoying but seemingly necessary to avoid a few issues with pytest<->attrs interaction.